### PR TITLE
Make error messages match other repos

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,7 @@ def create_checkout():
         flash('Transaction status - %s' % result.transaction.status)
         return redirect(url_for('show_checkout', transaction_id=result.transaction.id))
     else:
-        for x in result.errors.deep_errors: flash(x.message)
+        for x in result.errors.deep_errors: flash('Error: %s: %s' % (x.code, x.message))
         return redirect(url_for('new_checkout'))
 
 if __name__ == '__main__':

--- a/test_app.py
+++ b/test_app.py
@@ -78,8 +78,8 @@ class AppTestCase(unittest.TestCase):
             'payment_method_nonce': 'some_invalid_nonce',
             'amount': '12.34',
         })
-        self.assertIn('Transaction was unsuccessful', res.data)
-        self.assertIn('Transaction was really unsuccessful', res.data)
+        self.assertIn('Error: 12345: Transaction was unsuccessful', res.data)
+        self.assertIn('Error: 67890: Transaction was really unsuccessful', res.data)
 
     @mock.patch('braintree.Transaction.sale', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_SALE_UNSUCCESSFUL_PROCESSOR))
     def test_checkouts_create_redirects_to_checkouts_new_when_processor_errors_present(self):

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -38,8 +38,8 @@ MockObjects.TRANSACTION_SALE_UNSUCCESSFUL = mock.Mock(
     is_success = False,
     errors = mock.Mock(
         deep_errors = [
-            mock.Mock(message='Transaction was unsuccessful'),
-            mock.Mock(message='Transaction was really unsuccessful'),
+            mock.Mock(message='Error: 12345: Transaction was unsuccessful'),
+            mock.Mock(message='Error: 67890: Transaction was really unsuccessful'),
         ]
     ),
     transaction = None


### PR DESCRIPTION
Minor change to error message wording to `Error: [code]: [message]` to match other repos.
