### PR TITLE
Add Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+  - "2.7"
+  - "3.5"
+install: "pip install -r requirements.txt"
+script: "python test_app.py"
+notifications:
+  email:
+    - "external-ci-notifications+braintree_flask_example@getbraintree.com"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # Braintree Flask Example
+[![Build Status](https://travis-ci.org/braintree/braintree_flask_example.svg?branch=master)](https://travis-ci.org/braintree/braintree_flask_example)
+
 An example Braintree integration for python in the Flask framework.
 
 ## Setup Instructions


### PR DESCRIPTION
Adds a Travis CI integration to publicly display that build status of master and to enforce passing specs for PR's.