### PR TITLE
Modifications to make app python3 capable

### DIFF
--- a/test_app.py
+++ b/test_app.py
@@ -17,51 +17,51 @@ class AppTestCase(unittest.TestCase):
 
     def test_checkouts_new_route_available(self):
         res = self.app.get('/checkouts/new')
-        self.assertEquals(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_root_redirect_to_checkout(self):
         res = self.app.get('/')
-        self.assertEquals(res.status_code, 302)
+        self.assertEqual(res.status_code, 302)
         self.assertIn('/checkouts/new', res.location)
 
     def test_checkout_contains_client_token(self):
         res = self.app.get('/checkouts/new')
-        self.assertIn('var client_token = \'test_client_token\';', res.data)
+        self.assertIn(b'var client_token = \'test_client_token\';', res.data)
 
     def test_checkout_contains_checkout_form(self):
         res = self.app.get('/checkouts/new')
-        self.assertIn('<form id="payment-form"', res.data)
+        self.assertIn(b'<form id="payment-form"', res.data)
 
     def test_checkout_contains_dropin_div(self):
         res = self.app.get('/checkouts/new')
-        self.assertIn('<div id="bt-dropin"', res.data)
+        self.assertIn(b'<div id="bt-dropin"', res.data)
 
     def test_checkout_includes_amount_input(self):
         res = self.app.get('/checkouts/new')
-        self.assertIn('<label for="amount"', res.data)
-        self.assertIn('<input id="amount" name="amount" type="tel"', res.data)
+        self.assertIn(b'<label for="amount"', res.data)
+        self.assertIn(b'<input id="amount" name="amount" type="tel"', res.data)
 
     def test_checkouts_show_route_available(self):
         res = self.app.get('/checkouts/1')
-        self.assertEquals(res.status_code, 200)
+        self.assertEqual(res.status_code, 200)
 
     def test_checkouts_show_displays_info(self):
         res = self.app.get('/checkouts/1')
-        self.assertIn('my_id', res.data)
-        self.assertIn('10.00', res.data)
-        self.assertIn('MasterCard', res.data)
-        self.assertIn('ijkl', res.data)
-        self.assertIn('Billson', res.data)
-        self.assertIn('Billy Bobby Pins', res.data)
+        self.assertIn(b'my_id', res.data)
+        self.assertIn(b'10.00', res.data)
+        self.assertIn(b'MasterCard', res.data)
+        self.assertIn(b'ijkl', res.data)
+        self.assertIn(b'Billson', res.data)
+        self.assertIn(b'Billy Bobby Pins', res.data)
 
     def test_checkouts_show_displays_success_message_when_transaction_succeeded(self):
         res = self.app.get('/checkouts/1')
-        self.assertIn('Sweet Success!', res.data)
+        self.assertIn(b'Sweet Success!', res.data)
 
     def test_checkouts_show_displays_failure_message_when_transaction_failed(self):
         with mock.patch('braintree.Transaction.find', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_FAILURE)):
             res = self.app.get('/checkouts/1')
-            self.assertIn('Transaction Failed', res.data)
+            self.assertIn(b'Transaction Failed', res.data)
 
     @mock.patch('braintree.Transaction.sale', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_SALE_SUCCESSFUL))
     def test_checkouts_create_redirects_to_checkouts_show(self):
@@ -69,7 +69,7 @@ class AppTestCase(unittest.TestCase):
             'payment_method_nonce': 'some_nonce',
             'amount': '12.34',
         })
-        self.assertEquals(res.status_code, 302)
+        self.assertEqual(res.status_code, 302)
         self.assertIn('/checkouts/my_id', res.location)
 
     @mock.patch('braintree.Transaction.sale', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_SALE_SUCCESSFUL))
@@ -80,7 +80,7 @@ class AppTestCase(unittest.TestCase):
                 'amount': '12.34',
             })
 
-            self.assertNotIn('Customer Details', res.data)
+            self.assertNotIn(b'Customer Details', res.data)
 
     @mock.patch('braintree.Transaction.sale', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_SALE_UNSUCCESSFUL))
     def test_checkouts_create_redirects_to_checkouts_new_when_transaction_unsuccessful(self):
@@ -88,7 +88,7 @@ class AppTestCase(unittest.TestCase):
             'payment_method_nonce': 'some_invalid_nonce',
             'amount': '12.34',
         })
-        self.assertEquals(res.status_code, 302)
+        self.assertEqual(res.status_code, 302)
         self.assertIn('/checkouts/new', res.location)
 
     @mock.patch('braintree.Transaction.sale', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_SALE_UNSUCCESSFUL))
@@ -97,8 +97,8 @@ class AppTestCase(unittest.TestCase):
             'payment_method_nonce': 'some_invalid_nonce',
             'amount': '12.34',
         })
-        self.assertIn('Error: 12345: Transaction was unsuccessful', res.data)
-        self.assertIn('Error: 67890: Transaction was really unsuccessful', res.data)
+        self.assertIn(b'Error: 12345: Transaction was unsuccessful', res.data)
+        self.assertIn(b'Error: 67890: Transaction was really unsuccessful', res.data)
 
     @mock.patch('braintree.Transaction.sale', staticmethod(lambda x: test_helpers.MockObjects.TRANSACTION_SALE_UNSUCCESSFUL_PROCESSOR))
     def test_checkouts_create_redirects_to_checkouts_new_when_processor_errors_present(self):
@@ -115,7 +115,7 @@ class AppTestCase(unittest.TestCase):
                 'payment_method_nonce': 'some_invalid_nonce',
                 'amount': '2000',
             })
-            self.assertIn('Your test transaction has a status of processor_declined.', res.data)
+            self.assertIn(b'Your test transaction has a status of processor_declined.', res.data)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
We have a few items in our test that limit our ability to run in Python 3. 

Switched from deprecated `assertEquals` and made strings bytestrings where applicable. Tested in 2.7 and 3.5.