### PR TITLE
submit transaction for settlement by default

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,6 +60,9 @@ def create_checkout():
     result = braintree.Transaction.sale({
         'amount': request.form['amount'],
         'payment_method_nonce': request.form['payment_method_nonce'],
+        'options': {
+            "submit_for_settlement": True
+        }
     })
 
     if result.is_success or result.transaction:

--- a/test_app.py
+++ b/test_app.py
@@ -53,6 +53,7 @@ class AppTestCase(unittest.TestCase):
         self.assertIn(b'ijkl', res.data)
         self.assertIn(b'Billson', res.data)
         self.assertIn(b'Billy Bobby Pins', res.data)
+        self.assertIn(b'submitted_for_settlement', res.data)
 
     def test_checkouts_show_displays_success_message_when_transaction_succeeded(self):
         res = self.app.get('/checkouts/1')

--- a/test_helpers.py
+++ b/test_helpers.py
@@ -7,7 +7,7 @@ class MockObjects:
         id = 'my_id',
         type = 'sale',
         amount = '10.00',
-        status = 'authorized',
+        status = 'submitted_for_settlement',
         created_at = '03/01/1994',
         updated_at = '03/01/1994',
         credit_card_details = mock.Mock(


### PR DESCRIPTION
## Submit transactions for settlement by default

Currently, transactions are not submitted for settlement on the checkouts page. This would submit them automatically. For people using this repository to test out Braintree, this is useful as they don't have to manually submit each transaction they make in sandbox.