### PR TITLE
Bump dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask>=0.10.1
-braintree>=3.22.0
+braintree>=3.44.0
 MarkupSafe>=0.23
 mock>=1.3.0
 Werkzeug>=0.7

--- a/templates/checkouts/new.html
+++ b/templates/checkouts/new.html
@@ -32,7 +32,7 @@
   </div>
 </div>
 
-<script src="https://js.braintreegateway.com/web/dropin/1.9.4/js/dropin.min.js"></script>
+<script src="https://js.braintreegateway.com/web/dropin/1.10.0/js/dropin.min.js"></script>
 <script>
   var form = document.querySelector('#payment-form');
   var client_token = '{{ client_token }}';


### PR DESCRIPTION
Braintree Python to 3.44.0
Braintree Drop-in to 1.10.0