### PR TITLE
Fixed broken link in README.md Pro Tips section

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sandbox transactions must be made with [sample credit card numbers](https://deve
 
 ## Pro Tips
 
-- The `application.cfg.example` contains an `APP_SECRET_KEY` setting. Even in development you should [generate your own custom secret key for your app](http://flask.pocoo.org/docs/1.0/quickstart/#sessions).
+- The `application.cfg.example` contains an `APP_SECRET_KEY` setting. Even in development you should [generate your own custom secret key for your app](http://flask.pocoo.org/docs/0.12/quickstart/#sessions).
 
 ## Help
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sandbox transactions must be made with [sample credit card numbers](https://deve
 
 ## Pro Tips
 
-- The `application.cfg.example` contains an `APP_SECRET_KEY` setting. Even in development you should [generate your own custom secret key for your app](http://flask.pocoo.org/docs/0.10/quickstart/#sessions).
+- The `application.cfg.example` contains an `APP_SECRET_KEY` setting. Even in development you should [generate your own custom secret key for your app](http://flask.pocoo.org/docs/1.0/quickstart/#sessions).
 
 ## Help
 


### PR DESCRIPTION
Updated README.md [Pro Tips](https://github.com/braintree/braintree_flask_example#pro-tips) section to include the correct link to documentation for generating your own custom secret key.