### PR TITLE
Python3 & general updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-- '2.7'
 - '3.5'
 install: pip install -r requirements.txt
 script: python test_app.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7
+FROM python:3.5.3
 
 RUN apt-get update && apt-get install -y build-essential
 

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ An example Braintree integration for python in the Flask framework.
 
 1. Install requirements:
   ```sh
-  pip install -r requirements.txt
+  pip3 install -r requirements.txt
   ```
 
 2. Copy the contents of `example.env` into a new file named `.env` and fill in your Braintree API credentials. Credentials can be found by navigating to Account > My User > View Authorizations in the Braintree Control Panel. Full instructions can be [found on our support site](https://articles.braintreepayments.com/control-panel/important-gateway-credentials#api-credentials).
 
 3. Start server:
   ```sh
-  python app.py
+  python3 app.py
   ```
 
   By default, this runs the app on port `4567`. You can configure the port by setting the environmental variable `PORT`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3.7'
 services:
   web:
     build: .

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==1.0.3
-braintree>=3.51.0
+Flask==1.1.1
+braintree>=4.0.0
 MarkupSafe>=0.23
 mock>=1.3.0
 Werkzeug>=0.7
@@ -8,5 +8,5 @@ itsdangerous>=0.21
 requests<3.0,>=0.11.1
 pbr>=0.11
 six>=1.7
-python-dotenv==0.10.3
-gunicorn==19.9.0
+python-dotenv==0.12.0
+gunicorn==20.0.4


### PR DESCRIPTION
## what

- updates Docker files to use python 3.5 and Docker v3.7 (tested this by running `docker-compose up` and tested out loaded on my localhost fine)
- updates Braintree to v4.0.0
- used [pip-upgrader](https://github.com/simion/pip-upgrader) to run updates on packages with hard requirements (`==`) for general upkeep