### PR TITLE
Update Flask to 2.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Flask==1.1.1
+Flask==2.0.1
 braintree>=4.0.0
 MarkupSafe>=0.23
 mock>=1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 Flask==2.0.1
 braintree>=4.0.0
-MarkupSafe>=0.23
+MarkupSafe>=2.0
 mock>=1.3.0
-Werkzeug>=0.7
-Jinja2>=2.4
-itsdangerous>=0.21
+Werkzeug>=2.0
+Jinja2<3.1,>=3.0
+itsdangerous>=2.0
 requests<3.0,>=0.11.1
 pbr>=0.11
 six>=1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ braintree>=4.0.0
 MarkupSafe>=2.0
 mock>=1.3.0
 Werkzeug>=2.0
+# Jinja 3.1 has breaking changes TO-DO: find proper fix for later versions
 Jinja2<3.1,>=3.0
 itsdangerous>=2.0
 requests<3.0,>=0.11.1


### PR DESCRIPTION
Standing this up locally yields the error:
```Traceback (most recent call last):
  File "app.py", line 1, in <module>
    from flask import Flask, redirect, url_for, render_template, request, flash
  File "/home/afolksetapart/code/bt_test/braintree_flask_example/venv/lib/python3.8/site-packages/flask/__init__.py", line 19, in <module>
    from . import json
  File "/home/afolksetapart/code/bt_test/braintree_flask_example/venv/lib/python3.8/site-packages/flask/json/__init__.py", line 15, in <module>
    from itsdangerous import json as _json
ImportError: cannot import name 'json' from 'itsdangerous' (/home/jmichelini/code/bt_test/braintree_flask_example/venv/lib/python3.8/site-packages/itsdangerous/__init__.py)
```
The issue is due to a breaking change in newer versions of `markupsafe`.

Alternatively could update `flask` and pin `markupsafe`, or pin `itsdangerous` to compatible version.