### PR TITLE
drop deploy to heroku button

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,6 @@ An example Braintree integration for python in the Flask framework.
 
   By default, this runs the app on port `4567`. You can configure the port by setting the environmental variable `PORT`.
 
-## Deploying to Heroku
-
-You can deploy this app directly to Heroku to see the app live. Skip the setup instructions above and click the button below. This will walk you through getting this app up and running on Heroku in minutes.
-
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/braintree/braintree_flask_example&env[BT_ENVIRONMENT]=sandbox)
-
 ## Running tests
 
 Unit tests do not make API calls to Braintree and do not require Braintree credentials. You can run this project's unit tests by calling `python test_app.py` on the command line.


### PR DESCRIPTION
# Why
Heroku is dropping its tier of free service.

# What
Removes the button and instructions on deploying to Heroku.